### PR TITLE
Rewrite task organization. Fixes #11.

### DIFF
--- a/bin/yarnhack
+++ b/bin/yarnhack
@@ -3,10 +3,10 @@
 // Copyright 2017 Palantir Technologies Inc.
 
 const chalk = require('chalk');
-
+const _ = require('lodash');
 const fs = require('fs');
 
-const { linkAllPackagesToEachOther } = require('../lib/linking');
+const { linkPackages } = require('../lib/linking');
 const { getPackagesPath, getPackages } = require('../lib/packages');
 const { runYarnWithPackageJsonMangling } = require('../lib/yarn-with-package-json-mangling');
 
@@ -22,8 +22,8 @@ if (!fs.existsSync('package.json')) {
   }, packagesByName);
 
   child.on('exit', (code, signal) => {
-    const packageCount = linkAllPackagesToEachOther(getPackagesPath());
-    console.error(`yarnhack: re-linked ${chalk.cyan(packageCount)} local packages`);
+    linkPackages(packagesByName);
+    console.error(`yarnhack: re-linked ${chalk.cyan(_.size(packagesByName))} local packages`);
     process.exitCode = code;
   });
 

--- a/bin/yerna
+++ b/bin/yerna
@@ -164,7 +164,7 @@ commander
   .option('--dependents', 'additionally include all transitive dependents of selected packages (even when excluded)', false)
   .option('--dependencies', 'additionally include all transitive dependencies of selected packages (even when excluded)', false)
   .option('-p, --parallel <n>', 'run up to <n> processes in parallel (default: 4)', optParallel, 4)
-  .option('-l, --loglevel <level>', 'set the log level for Yerna', optEnum([ 'verbose', 'info', 'warn', 'error' ], 'loglevel'), 'info')
+  .option('-l, --loglevel <level>', 'set the log level for Yerna', optEnum([ 'debug', 'verbose', 'info', 'warn', 'error' ], 'loglevel'), 'info')
   .option('-c, --no-color', 'disable colorized output', false);
 
 commander.on('--help', () =>{

--- a/bin/yerna
+++ b/bin/yerna
@@ -14,22 +14,145 @@ const fs = require('fs');
 const Promise = require('bluebird');
 
 const { getPackagesPath, getPackages } = require('../lib/packages');
-const { linkAllPackagesToEachOther } = require('../lib/linking');
+const { linkPackages, WithLinking } = require('../lib/linking');
 const { runYarnWithPackageJsonMangling } = require('../lib/yarn-with-package-json-mangling');
-const { logger, deleteLogFile, LoggerWrapper } = require('../lib/logger');
-const { createTaskRunner, runPackagesToposorted, abort } = require('../lib/taskrunning');
+const { logger, deleteLogFile } = require('../lib/logger');
+const { filterPackages, logFlagFeedback } = require('../lib/filtering');
+const { createTaskRunner, runPackagesToposorted, abort, WithAbort } = require('../lib/taskrunning');
+
+const PACKAGES_PATH = getPackagesPath();
+
+if (!fs.existsSync(PACKAGES_PATH)) {
+  logger.error(chalk.red(`path ${PACKAGES_PATH} does not exist`));
+  process.exitCode = 1;
+}
+
+const PACKAGES = getPackages(PACKAGES_PATH);
+
+let didInit = false;
+function WithInit(fn) {
+  return function() {
+    if (didInit) {
+      throw new Error('cannot initialize twice!');
+    }
+    didInit = true;
+
+    logger.transports.console.level = commander.loglevel;
+
+    if (!commander.color) {
+      chalk.enabled = false;
+    }
+
+    // 10 for default, then one for each of the 'exit' handlers we know will be attached by child processes.
+    // All this does is prevent warnings, but it's good practice.
+    process.setMaxListeners(10 + commander.parallel);
+
+    deleteLogFile();
+
+    const startTime = Date.now();
+
+    function logTiming(verbiage) {
+      logger.info(`yerna: ${verbiage} ${((Date.now() - startTime) / 1000).toFixed(2)}s`);
+    }
+
+    process.on('exit', () => {
+      if (process.exitCode === 0) {
+        deleteLogFile();
+        logTiming('took');
+      } else {
+        logTiming('failed after');
+      }
+    });
+
+    process.on('SIGINT', () => {
+      logger.error(chalk.red('yerna: received sigint, terminating...'));
+      abort(null, { userInitiated: true });
+    });
+
+    if (process.exitCode === 0) {
+      return fn.apply(this, arguments);
+    } else {
+      // Do nothing; wait for process to exit...
+    }
+  }
+}
+
+function decorate(fn, ...decorators) {
+  return decorators.slice().reverse().reduce((decoratedFn, decorator) => decorator(decoratedFn), fn);
+}
+
+const performLink = decorate(function() {
+  linkPackages(PACKAGES);
+  logger.info(`yerna: linked ${chalk.cyan(_.size(PACKAGES))} local packages`);
+}, WithAbort, WithInit);
+
+const performInstall = decorate(function(moreArgs) {
+  const filteredPackages = filterPackages(PACKAGES, commander);
+  const yarnArgs = [ 'install' ].concat(moreArgs);
+  logFlagFeedback(commander, filteredPackages, 'yarn ' + yarnArgs.join(' '));
+  return runPackagesToposorted(
+    filteredPackages,
+    createTaskRunner(spawnArgs => runYarnWithPackageJsonMangling(yarnArgs, spawnArgs, PACKAGES)),
+    commander.parallel
+  );
+}, WithAbort, WithInit, WithLinking(PACKAGES));
+
+const performList = decorate(function() {
+  const filteredPackages = filterPackages(PACKAGES, commander);
+  logFlagFeedback(commander, filteredPackages);
+  return runPackagesToposorted(
+    filteredPackages,
+    (pkg) => {
+      logger.info(pkg.name);
+      return Promise.resolve();
+    },
+    commander.parallel
+  );
+}, WithAbort, WithInit);
+
+const performRun = decorate(function(scriptName, moreArgs) {
+  const filteredPackages = filterPackages(PACKAGES, commander, pkg => !!pkg.scripts[scriptName]);
+  const yarnArgs = [ 'run', scriptName  ].concat(moreArgs);
+  logFlagFeedback(commander, filteredPackages, 'yarn ' + yarnArgs.join(' '), [ `have a ${chalk.magenta(scriptName)} script` ]);
+  return runPackagesToposorted(
+    filteredPackages,
+    createTaskRunner(spawnArgs => runYarnWithPackageJsonMangling(yarnArgs, spawnArgs, PACKAGES)),
+    commander.parallel
+  );
+}, WithAbort, WithInit, WithLinking(PACKAGES));
+
+const performExec = decorate(function(binaryName, moreArgs) {
+  const filteredPackages = filterPackages(PACKAGES, commander);
+  logFlagFeedback(commander, filteredPackages, [ binaryName ].concat(moreArgs).join(' '));
+  return runPackagesToposorted(
+    filteredPackages,
+    createTaskRunner(spawnArgs => child_process.spawn(binaryName, moreArgs, spawnArgs)),
+    commander.parallel
+  );
+}, WithAbort, WithInit, WithLinking(PACKAGES));
 
 function optParallel(n) {
   if (n == null || +n <= 0 || Math.round(n) !== +n) {
     console.error(chalk.red('yerna: parallel option must be a positive integer'));
-    // Should probably be exitCode = 1.
-    process.exit(1);
+    process.exitCode = 1;
+  } else {
+    return +n;
   }
-  return +n;
 }
 
 function concatOpt(opt, allOpts) {
   return allOpts.concat([ opt ]);
+}
+
+function optEnum(values, optName) {
+  return function(opt) {
+    if (values.indexOf(opt) === -1) {
+      console.error(chalk.red(`yerna: ${optName} option must be one of '${values.join('\', \'')}'`));
+      process.exitCode = 1;
+    } else {
+      return opt;
+    }
+  };
 }
 
 commander
@@ -41,8 +164,27 @@ commander
   .option('--dependents', 'additionally include all transitive dependents of selected packages (even when excluded)', false)
   .option('--dependencies', 'additionally include all transitive dependencies of selected packages (even when excluded)', false)
   .option('-p, --parallel <n>', 'run up to <n> processes in parallel (default: 4)', optParallel, 4)
-  .option('-l, --loglevel <level>', 'set the log level for Yerna', /^(verbose|info|warn|error)$/i, 'info')
+  .option('-l, --loglevel <level>', 'set the log level for Yerna', optEnum([ 'verbose', 'info', 'warn', 'error' ], 'loglevel'), 'info')
   .option('-c, --no-color', 'disable colorized output', false);
+
+commander.on('--help', () =>{
+  [
+    '  Notes:',
+    '',
+    '    - Use -- to separate arguments intended for Yarn. See examples.',
+    '    - Most tasks automatically relink local dependencies; `yerna link` usage should be rare.',
+    '',
+    '  Examples:',
+    '',
+    '    $ yerna install',
+    '    $ yerna install --include foo',
+    '    $ yerna install -- --pure-lockfile',
+    '    $ yerna install --include foo --include bar -- --pure-lockfile',
+    '    $ yerna run taskname --include foo --exclude bar',
+    '    $ yerna exec ls -- -la',
+    ''
+  ].forEach(line => console.log(line));
+});
 
 commander
   .command('install -- [args...]')
@@ -68,172 +210,6 @@ commander
   .command('exec <executable> -- [args...]')
   .description('run `<executable> <args>` for the specified packages')
   .action(performExec);
-
-commander.on('--help', () =>{
-  [
-    '  Notes:',
-    '',
-    '    - Use -- to separate arguments intended for Yarn. See examples.',
-    '    - Most tasks automatically relink local dependencies; `yerna link` usage should be rare.',
-    '',
-    '  Examples:',
-    '',
-    '    $ yerna install',
-    '    $ yerna install --include foo',
-    '    $ yerna install -- --pure-lockfile',
-    '    $ yerna install --include foo --include bar -- --pure-lockfile',
-    '    $ yerna run taskname --include foo --exclude bar',
-    '    $ yerna exec ls -- -la',
-    ''
-  ].forEach(line => console.log(line));
-});
-
-let didInit = false;
-function sideEffectingInit() {
-  if (didInit) {
-    return;
-  }
-  didInit = true;
-
-  logger.transports.console.level = commander.loglevel;
-
-  if (!commander.color) {
-    chalk.enabled = false;
-  }
-
-  // 10 for default, then one for each of the 'exit' handlers we know will be attached by child processes.
-  // All this does is prevent warnings, but it's good practice.
-  process.setMaxListeners(10 + commander.parallel);
-
-  deleteLogFile();
-
-  process.on('exit', () => {
-    if (process.exitCode === 0) {
-      deleteLogFile();
-    }
-  });
-
-  process.on('SIGINT', () => {
-    logger.error(chalk.red('yerna: received sigint, terminating...'));
-    abort();
-  });
-}
-
-function findTransitiveDependentsOrDependencies(allPackages, rootPackageName, typeKey) {
-  const selectedPackageNames = [];
-  let packageQueue = [ allPackages[rootPackageName] ];
-  while (packageQueue.length) {
-    const currentPackage = packageQueue.shift();
-    if (selectedPackageNames.indexOf(currentPackage.name) === -1) {
-      selectedPackageNames.push(currentPackage.name);
-      packageQueue = packageQueue.concat(currentPackage[typeKey].map(packageName => allPackages[packageName]))
-    }
-  }
-  return selectedPackageNames.map(packageName => allPackages[packageName]);
-}
-
-function maybeIncludeDependentsAndDependencies(allPackages, package) {
-  let packages = [ package ];
-
-  if (commander.dependents) {
-    packages = packages.concat(_.flatMap(packages, pkg => findTransitiveDependentsOrDependencies(allPackages, pkg.name, 'localDependents')));
-  }
-
-  if (commander.dependencies) {
-    packages = packages.concat(_.flatMap(packages, pkg => findTransitiveDependentsOrDependencies(allPackages, pkg.name, 'localDependencies')));
-  }
-
-  return _.uniqBy(packages, 'name');
-}
-
-function applyIncludeExclude(package) {
-  return (
-    (commander.include.length === 0 || commander.include.some(regex => new RegExp(regex).test(package.name))) &&
-    (commander.exclude.length === 0 || !commander.exclude.some(regex => new RegExp(regex).test(package.name)))
-  );
-};
-
-function getSelectedPackages(additionalFilter = () => true) {
-  const packagesPath = getPackagesPath();
-
-  if (!fs.existsSync(packagesPath)) {
-    throw new Error(`path ${packagesPath} does not exist`);
-  }
-
-  const packagesByName = getPackages(packagesPath);
-  const selectedPackages = _.chain(packagesByName)
-    .values()
-    .filter(applyIncludeExclude)
-    .flatMap(pkg => maybeIncludeDependentsAndDependencies(packagesByName, pkg))
-    .uniqBy('name')
-    .sortBy('name')
-    .filter(additionalFilter)
-    .value();
-
-  return { packagesPath, packagesByName, selectedPackages };
-}
-
-function performLink() {
-  const startTime = Date.now();
-  sideEffectingInit();
-  const packageCount = linkAllPackagesToEachOther(getPackagesPath());
-  logger.info(`yerna: linked ${chalk.cyan(packageCount)} local packages`);
-  LoggerWrapper.logSuccessTiming(startTime);
-}
-
-function performInstall(moreArgs) {
-  sideEffectingInit();
-  const yarnArgs = [ 'install' ].concat(moreArgs);
-  const { packagesPath, packagesByName, selectedPackages } = getSelectedPackages();
-  runPackagesToposorted(
-    new LoggerWrapper(commander, selectedPackages, 'yarn ' + yarnArgs.join(' ')),
-    commander,
-    packagesPath,
-    selectedPackages,
-    createTaskRunner(spawnArgs => runYarnWithPackageJsonMangling(yarnArgs, spawnArgs, packagesByName))
-  );
-}
-
-function performList() {
-  const startTime = Date.now();
-  sideEffectingInit();
-  const { packagesPath, selectedPackages } = getSelectedPackages();
-  runPackagesToposorted(
-    new LoggerWrapper(commander, selectedPackages),
-    commander,
-    packagesPath,
-    selectedPackages,
-    (pkg) => {
-      logger.info(pkg.name);
-      return Promise.resolve();
-    }
-  );
-}
-
-function performRun(scriptName, moreArgs) {
-  sideEffectingInit();
-  const yarnArgs = [ 'run', scriptName  ].concat(moreArgs);
-  const { packagesPath, packagesByName, selectedPackages } = getSelectedPackages(package => !!package.scripts[scriptName]);
-  runPackagesToposorted(
-    new LoggerWrapper(commander, selectedPackages, 'yarn ' + yarnArgs.join(' '), scriptName),
-    commander,
-    packagesPath,
-    selectedPackages,
-    createTaskRunner(spawnArgs => runYarnWithPackageJsonMangling(yarnArgs, spawnArgs, packagesByName))
-  );
-}
-
-function performExec(binaryName, moreArgs) {
-  sideEffectingInit();
-  const { packagesPath, selectedPackages } = getSelectedPackages();
-  runPackagesToposorted(
-    new LoggerWrapper(commander, selectedPackages, binaryName + [ '' ].concat(moreArgs).join(' ')),
-    commander,
-    packagesPath,
-    selectedPackages,
-    createTaskRunner(spawnArgs => child_process.spawn(binaryName, moreArgs, spawnArgs))
-  );
-}
 
 commander.parse(process.argv);
 

--- a/lib/filtering.js
+++ b/lib/filtering.js
@@ -100,6 +100,9 @@ function logFlagFeedback(commander, filteredPackages, commandPhrase, additionalF
 
     logger.info(logline);
   }
+
+  logger.verbose('yerna: selected packages are:');
+  filteredPackages.forEach(pkg => logger.verbose(`yerna:  - ${pkg.name}`));
 }
 
 module.exports = {

--- a/lib/filtering.js
+++ b/lib/filtering.js
@@ -1,0 +1,108 @@
+// Copyright 2017 Palantir Technologies Inc.
+
+const chalk = require('chalk');
+const _ = require('lodash');
+const fs = require('fs');
+const { logger } = require('./logger');
+
+function findTransitiveDependentsOrDependencies(packagesByName, rootPackageName, typeKey) {
+  const selectedPackageNames = [];
+  let packageQueue = [ packagesByName[rootPackageName] ];
+  while (packageQueue.length) {
+    const currentPackage = packageQueue.shift();
+    if (selectedPackageNames.indexOf(currentPackage.name) === -1) {
+      selectedPackageNames.push(currentPackage.name);
+      packageQueue = packageQueue.concat(currentPackage[typeKey].map(packageName => packagesByName[packageName]))
+    }
+  }
+  return selectedPackageNames.map(packageName => packagesByName[packageName]);
+}
+
+function maybeIncludeDependentsAndDependencies(packagesByName, pkg, { dependents, dependencies }) {
+  let packages = [ pkg ];
+
+  if (dependents) {
+    packages = packages.concat(_.flatMap(packages, pkg => findTransitiveDependentsOrDependencies(packagesByName, pkg.name, 'localDependents')));
+  }
+
+  if (dependencies) {
+    packages = packages.concat(_.flatMap(packages, pkg => findTransitiveDependentsOrDependencies(packagesByName, pkg.name, 'localDependencies')));
+  }
+
+  return _.uniqBy(packages, 'name');
+}
+
+function applyIncludeExclude(pkg, { include, exclude }) {
+  return (
+    (include.length === 0 || include.some(regex => new RegExp(regex).test(pkg.name))) &&
+    (exclude.length === 0 || !exclude.some(regex => new RegExp(regex).test(pkg.name)))
+  );
+};
+
+function filterPackages(packagesByName, commander, additionalFilter = () => true) {
+  const filteredPackages = _.chain(packagesByName)
+    .values()
+    .filter(pkg => applyIncludeExclude(pkg, commander))
+    .flatMap(pkg => maybeIncludeDependentsAndDependencies(packagesByName, pkg, commander))
+    .uniqBy('name')
+    .sortBy('name')
+    .filter(additionalFilter)
+    .value();
+
+  return filteredPackages;
+}
+
+function formatList(strings, conjunction = 'or', oxfordComma = false) {
+  if (oxfordComma) {
+    throw new Error(`yerna: oops, don't use an Oxford comma!`);
+  }
+
+  if (strings.length <= 1) {
+    return strings.join('');
+  } else {
+    return `${strings.slice(0, strings.length - 1).join(', ')} ${conjunction} ${strings[strings.length - 1]}`
+  }
+}
+
+function logFlagFeedback(commander, filteredPackages, commandPhrase, additionalFilters = []) {
+  const include = commander.include.length ? formatList(commander.include.map(r => chalk.magenta(r))) : null;
+  const exclude = commander.exclude.length ? formatList(commander.exclude.map(r => chalk.magenta(r))) : null;
+  const { dependents, dependencies } = commander;
+
+  logger.info(`yerna: ${commandPhrase ? 'running ' + chalk.cyan(commandPhrase) + ' for ' : ''}${chalk.cyan(filteredPackages.length)} package(s)`);
+
+  if (include) {
+    logger.info(`yerna:  - that match ${include}`);
+  }
+
+  if (exclude) {
+    logger.info(`yerna:  - that do not match ${exclude}`);
+  }
+
+  additionalFilters.forEach(filter => {
+    logger.info(`yerna:  - that ${filter}`);
+  });
+
+  if (dependents || dependencies) {
+    let logline = '';
+
+    if (dependents && dependencies) {
+      logline = `yerna:  - including ${chalk.magenta('all transitive dependents and their dependencies')}`;
+    } else if (dependents) {
+      logline = `yerna:  - including ${chalk.magenta('all transitive dependents')}`;
+    } else if (dependencies) {
+      logline = `yerna:  - including ${chalk.magenta('all transitive dependencies')}`;
+    }
+
+    if (exclude) {
+      logline += ` (even if they match --exclude)`;
+    }
+
+    logger.info(logline);
+  }
+}
+
+module.exports = {
+  filterPackages,
+  logFlagFeedback
+};

--- a/lib/linking.js
+++ b/lib/linking.js
@@ -5,8 +5,6 @@ const _ = require('lodash');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const fs = require('fs');
-
-const { getPackages } = require('./packages');
 const { logger } = require('./logger');
 
 function symlink(symlinkContent, symlinkPath) {
@@ -21,15 +19,17 @@ function symlink(symlinkContent, symlinkPath) {
   fs.symlinkSync(symlinkContent, symlinkPath);
 }
 
-function linkAllPackagesToEachOther(packageDirectory) {
-  const packages = getPackages(packageDirectory);
-
-  _.forEach(packages, (package, packageName) => {
+function linkPackages(packagesByName) {
+  _.forEach(packagesByName, (package, packageName) => {
     package.localDependencies.forEach(dependencyName => {
-      const dependency = packages[dependencyName];
+      const dependency = packagesByName[dependencyName];
+      if (!dependency) {
+        throw new Error(`programmer error: cannot link ${packageName} to ${dependencyName}`);
+      }
+
       const symlinkPath = path.resolve(package.path, 'node_modules', dependencyName);
       const symlinkDirectory = path.dirname(symlinkPath);
-      symlink(path.resolve(packageDirectory, dependency.path), symlinkPath);
+      symlink(dependency.path, symlinkPath);
 
       if (dependency.bin) {
         const binaryRoot = path.resolve(package.path, 'node_modules', '.bin');
@@ -40,23 +40,36 @@ function linkAllPackagesToEachOther(packageDirectory) {
       }
     });
   });
-
-  return _.size(packages);
 }
 
+function WithLinking(packagesByName) {
+  function prelink() {
+    linkPackages(packagesByName);
+    logger.verbose(`yerna: linked all ${chalk.cyan(_.size(packagesByName))} package(s) before running tasks`);
+  }
 
-function prelink(packageDirectory) {
-  const packageCount = linkAllPackagesToEachOther(packageDirectory);
-  logger.info(`yerna: linking all ${chalk.cyan(packageCount)} package(s) before running tasks`);
-}
+  function postlink() {
+    linkPackages(packagesByName);
+    logger.verbose(`yerna: re-linked all ${chalk.cyan(_.size(packagesByName))} package(s) after running tasks`);
+  }
 
-function postlink(packageDirectory) {
-  const packageCount = linkAllPackagesToEachOther(packageDirectory);
-  logger.info(`yerna: re-linking all ${chalk.cyan(packageCount)} package(s) after running tasks`);
+  return function (fn) {
+    return function() {
+      prelink();
+
+      const returnValue = fn.apply(this, arguments);
+
+      if (returnValue && typeof returnValue.then === 'function') {
+        return returnValue.tap(postlink);
+      } else {
+        postlink();
+        return returnValue;
+      }
+    };
+  };
 }
 
 module.exports = {
-  prelink,
-  postlink,
-  linkAllPackagesToEachOther
+  linkPackages,
+  WithLinking
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -14,7 +14,7 @@ const logger = new winston.Logger({
     new winston.transports.File({
       filename: LOG_FILENAME,
       json: false,
-      level: 'verbose'
+      level: 'debug'
     })
   ]
 });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,9 +1,7 @@
 // Copyright 2017 Palantir Technologies Inc.
 
-const chalk = require('chalk');
 const winston = require('winston');
 const fs = require('fs');
-const { formatErrorForConsole } = require('./error-handling');
 
 // TODO: This logfile should be relative to the repo root.
 const LOG_FILENAME = 'yerna.log';
@@ -27,90 +25,7 @@ function deleteLogFile() {
   }
 }
 
-function formatList(strings, conjunction = 'or', oxfordComma = false) {
-  if (oxfordComma) {
-    throw new Error(`yerna: oops, don't use an Oxford comma!`);
-  }
-
-  if (strings.length <= 1) {
-    return strings.join('');
-  } else {
-    return `${strings.slice(0, strings.length - 1).join(', ')} ${conjunction} ${strings[strings.length - 1]}`
-  }
-}
-
-class LoggerWrapper {
-  constructor(commander, packages, formattedCommand = null, withScriptName = null) {
-    this.commander = commander;
-    this.packages = packages;
-    this.formattedCommand = formattedCommand;
-    this.withScriptName = withScriptName;
-  }
-
-  logPrelude() {
-    const packageCount = this.packages.length;
-    const include = this.commander.include.length ? formatList(this.commander.include.map(r => chalk.magenta(r))) : null;
-    const exclude = this.commander.exclude.length ? formatList(this.commander.exclude.map(r => chalk.magenta(r))) : null;
-    const { dependents, dependencies } = this.commander;
-
-    let logline = '';
-
-    if (this.formattedCommand) {
-      logline += `yerna: running ${chalk.cyan(this.formattedCommand)} for ${chalk.cyan(packageCount)} package(s)`;
-    } else {
-      logline += `yerna: ${chalk.cyan(packageCount)} package(s)`;
-    }
-
-    if (include) {
-      logline += `\nyerna:  - that match ${include}`;
-    }
-
-    if (exclude) {
-      logline += `\nyerna:  - that do not match ${exclude}`;
-    }
-
-    if (this.withScriptName) {
-      logline += `\nyerna:  - that have a ${chalk.magenta(this.withScriptName)} script`;
-    }
-
-    if (dependents || dependencies) {
-      if (dependents && dependencies) {
-        logline += `\nyerna:  - including ${chalk.magenta('all transitive dependents and their dependencies')}`;
-      } else if (dependents) {
-        logline += `\nyerna:  - including ${chalk.magenta('all transitive dependents')}`;
-      } else if (dependencies) {
-        logline += `\nyerna:  - including ${chalk.magenta('all transitive dependencies')}`;
-      }
-
-      if (exclude) {
-        logline += ` (even if they match --exclude)`;
-      }
-    }
-
-    logger.info(logline);
-  }
-
-  logErrorPostlude(e) {
-    logger.error(chalk.bgRed(formatErrorForConsole(e)));
-    logger.error(chalk.bgRed('yerna: errors while running', this.formattedCommand, 'in', this.packages.length, 'package(s)'));
-    logger.error(chalk.bgRed('yerna: packages may be in an inconsistent state, including not being linked to each other'));
-  }
-
-  static logErrorTiming(startTime) {
-    logger.error(`yerna: aborted after ${Math.round((Date.now() - startTime) / 1000 * 100) / 100}s`);
-  }
-
-  logSuccessPostlude() {
-    logger.info(`yerna: ran ${this.formattedCommand ? chalk.cyan(this.formattedCommand) + ' ' : ''}successfully in ${chalk.cyan(this.packages.length)} package(s)${[ '' ].concat(this.packages.map(pkg => pkg.name)).join('\n - ')}`);
-  }
-
-  static logSuccessTiming(startTime) {
-    logger.info(`yerna: took ${Math.round((Date.now() - startTime) / 1000 * 100) / 100}s`);
-  }
-}
-
 module.exports = {
   logger,
-  LoggerWrapper,
   deleteLogFile
 };

--- a/lib/taskrunning.js
+++ b/lib/taskrunning.js
@@ -6,14 +6,11 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const async = require('async');
 
-const { logger, LoggerWrapper } = require('./logger');
-const { prelink, postlink } = require('./linking');
+const { logger } = require('./logger');
 const { formatErrorForConsole } = require('./error-handling');
 
 let spawnedProcesses = [];
 let isAborting = false;
-
-const START_TIME = Date.now();
 
 function trimLastNewline(s) {
   return s[s.length - 1] === '\n' ? s.slice(0, s.length - 1) : s;
@@ -57,8 +54,14 @@ function createTaskRunner(spawnChild) {
 
         spawnedProcesses = _.without(spawnedProcesses, child);
 
-        if (code !== 0 || signal) {
-          reject();
+        const didExitFail = code != null && code !== 0;
+        const didGetSignal = signal != null;
+        if (didExitFail || didGetSignal) {
+          const reasons = _.compact([
+            didGetSignal ? `task received signal ${signal}` : null,
+            didExitFail ? `task exited with code ${code}` : null
+          ]).join('; ');
+          reject(reasons);
         } else {
           resolve();
         }
@@ -67,9 +70,16 @@ function createTaskRunner(spawnChild) {
   }
 }
 
-function abort() {
+function abort(cause, { userInitiated } = {}) {
   if (isAborting) {
     return;
+  }
+
+  if (cause) {
+    logger.error(chalk.bgRed(formatErrorForConsole(cause)));
+  }
+  if (!userInitiated) {
+    logger.error(chalk.bgRed('yerna: errors while running tasks!'));
   }
 
   isAborting = true;
@@ -82,8 +92,9 @@ function abort() {
       spawnedProcesses.forEach(child => { child.kill(); })
 
       return new Promise((resolve, reject) => {
-        setInterval(() => {
+        const interval = setInterval(() => {
           if (spawnedProcesses.length === 0) {
+            clearInterval(interval);
             resolve();
           }
         }, 200);
@@ -98,15 +109,32 @@ function abort() {
       logger.error(chalk.bgRed('yerna: unexpected error during cleanup, exiting suddenly!'));
     })
     .finally(() => {
-      LoggerWrapper.logErrorTiming(START_TIME);
-      // TODO: If this is changed to process.exitCode, it doesn't work: something is keeping the process alive.
-      process.exit(1);
+      process.exitCode = 1;
     });
 }
 
-function runPackagesToposorted(logger, commander, packagesPath, packages, runTask) {
-  logger.logPrelude();
-  prelink(packagesPath);
+function WithAbort(fn) {
+  return function() {
+    let returnValue;
+    try {
+      returnValue = fn.apply(this, arguments);
+    } catch (e) {
+      abort(e);
+      return;
+    }
+
+    if (returnValue && typeof returnValue.then === 'function') {
+      return returnValue.catch(abort);
+    } else {
+      return returnValue;
+    }
+  };
+}
+
+function runPackagesToposorted(packages, runTask, parallel) {
+  if (packages.length === 0) {
+    return Promise.resolve();
+  }
 
   const packageByName = _.keyBy(packages, 'name');
 
@@ -131,13 +159,6 @@ function runPackagesToposorted(logger, commander, packagesPath, packages, runTas
     }
   }
 
-  function logAndAbort(e) {
-    if (!isAborting) {
-      logger.logErrorPostlude(e);
-      abort();
-    }
-  }
-
   const q = async.queue((pkg, callback) => {
     return runTask(pkg)
       .then(() => {
@@ -151,9 +172,8 @@ function runPackagesToposorted(logger, commander, packagesPath, packages, runTas
           });
       })
       .then(() => enqueueAvailablePackages({ breakCycles: false }))
-      .asCallback(callback)
-      .catch(logAndAbort);
-  }, commander.parallel);
+      .asCallback(callback);
+  }, parallel);
 
   enqueueAvailablePackages({ breakCycles: true });
 
@@ -170,17 +190,12 @@ function runPackagesToposorted(logger, commander, packagesPath, packages, runTas
       q.kill();
       reject(e);
     };
-  })
-    .then(() => {
-      postlink(packagesPath);
-      logger.logSuccessPostlude();
-      LoggerWrapper.logSuccessTiming(START_TIME);
-    })
-    .catch(logAndAbort);
+  });
 }
 
 module.exports = {
   createTaskRunner,
   runPackagesToposorted,
-  abort
+  abort,
+  WithAbort
 };

--- a/lib/taskrunning.js
+++ b/lib/taskrunning.js
@@ -46,6 +46,8 @@ function createTaskRunner(spawnChild) {
       });
 
       child.on('exit', (code, signal) => {
+        logger.debug(`yerna: (taskrunner) child pid ${child.pid} exited with code ${code} and signal ${signal}`);
+
         if (!isAborting && mergedOutput.length) {
           logger.info(`yerna: output for ${chalk.cyan(pkg.name)}`);
           mergedOutput.forEach(({ level, loglines }) => loglines.forEach(l => logger[level](l)));
@@ -71,13 +73,18 @@ function createTaskRunner(spawnChild) {
 }
 
 function abort(cause, { userInitiated } = {}) {
+  logger.debug(`yerna: received a request to abort, cause follows`);
+  logger.debug(formatErrorForConsole(cause));
+
   if (isAborting) {
+    logger.debug('yerna: already aborting, ignoring request');
     return;
   }
 
   if (cause) {
     logger.error(chalk.bgRed(formatErrorForConsole(cause)));
   }
+
   if (!userInitiated) {
     logger.error(chalk.bgRed('yerna: errors while running tasks!'));
   }
@@ -89,6 +96,7 @@ function abort(cause, { userInitiated } = {}) {
         logger.warn(chalk.red(`yerna: waiting for ${spawnedProcesses.length} child process(es) to exit`));
       }
 
+      logger.debug(`yerna: killing ${spawnedProcesses.length} processes, pids: ${spawnedProcesses.map(child => child.pid).join(', ')}`);
       spawnedProcesses.forEach(child => { child.kill(); })
 
       return new Promise((resolve, reject) => {
@@ -109,6 +117,7 @@ function abort(cause, { userInitiated } = {}) {
       logger.error(chalk.bgRed('yerna: unexpected error during cleanup, exiting suddenly!'));
     })
     .finally(() => {
+      logger.debug('yerna: child processes appear to have exited, continuing with abort');
       process.exitCode = 1;
     });
 }

--- a/lib/taskrunning.js
+++ b/lib/taskrunning.js
@@ -22,7 +22,8 @@ function createTaskRunner(spawnChild) {
       const spawnArgs = {
         cwd: pkg.path,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        detached: true
       };
 
       const child = spawnChild(spawnArgs);
@@ -97,7 +98,7 @@ function abort(cause, { userInitiated } = {}) {
       }
 
       logger.debug(`yerna: killing ${spawnedProcesses.length} processes, pids: ${spawnedProcesses.map(child => child.pid).join(', ')}`);
-      spawnedProcesses.forEach(child => { child.kill(); })
+      spawnedProcesses.forEach(child => { process.kill(-child.pid); })
 
       return new Promise((resolve, reject) => {
         const interval = setInterval(() => {

--- a/lib/taskrunning.js
+++ b/lib/taskrunning.js
@@ -74,8 +74,7 @@ function createTaskRunner(spawnChild) {
 }
 
 function abort(cause, { userInitiated } = {}) {
-  logger.debug(`yerna: received a request to abort, cause follows`);
-  logger.debug(formatErrorForConsole(cause));
+  logger.debug(`yerna: received a request to abort`);
 
   if (isAborting) {
     logger.debug('yerna: already aborting, ignoring request');
@@ -84,6 +83,8 @@ function abort(cause, { userInitiated } = {}) {
 
   if (cause) {
     logger.error(chalk.bgRed(formatErrorForConsole(cause)));
+  } else {
+    logger.debug('yerna: no abort cause was given'); 
   }
 
   if (!userInitiated) {

--- a/lib/yarn-with-package-json-mangling.js
+++ b/lib/yarn-with-package-json-mangling.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const path = require('path');
 const fs = require('fs');
 const child_process = require('child_process');
+const { logger } = require('./logger');
 
 function alphabetizeKeys(object) {
   const alphabetizedObject = {};
@@ -53,14 +54,16 @@ function runYarnWithPackageJsonMangling(args, spawnArgs, packagesByName) {
   const child = child_process.spawn('yarn', args, spawnArgs);
 
   const killOnExit = () => {
+    logger.debug(`yerna: (yarn wrapper) killing child ${child.pid} because parent process is exiting`);
     child.kill();
   };
 
   process.on('exit', killOnExit);
 
-  child.once('exit', () => {
+  child.once('exit', (code, signal) => {
     unmanglePackageJson(packageJsonPath, mangleToken);
     process.removeListener('exit', killOnExit);
+    logger.debug(`yerna: (yarn wrapper) child pid ${child.pid} exited with code ${code} and signal ${signal}`);
   });
 
   return child;


### PR DESCRIPTION
- Break out a new filtering.js from yerna.
- Make a "task" just a "function that returns a promise".
- Make a few generally-useful behaviors into decorators, so task
  definitions can concentrate on what makes them different.
- Use process.exitCode more liberally so on-exit logging can be
  more precise.
- Making linking take a set of packages, not a path.
- Move logging and other program-lifecycle tasks out of taskrunning
  so it can just do the actual task management/ordering.
- Chase down last async behavior that kept process alive when it
  should have exited.
- Remove silly LoggerWrapper, which was always a quick hack anyway.