### PR TITLE
Configure package directory globs in "yerna.json".

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,20 @@ exec \<command\> | run shell command \<command\> in packages              |
 
 Yerna is backwards-compatible with Lerna, in that it puts the repo into a valid state for Lerna. You can continue to use Lerna for features missing from Yerna (such as publishing), though be sure to [read the caveats](#caveats), in particular, the [behavior around symlinks](#symlinks).
 
-Yerna does not read or write any Yerna- or Lerna-specific files on the filesystem (except for a logfile); in particular, it does not read `lerna.json`.
+Yerna does not read or write any Lerna-specific files on the filesystem (except for a logfile); in particular, it does not read `lerna.json`.
+
+You can customise the paths where Yerna looks for packages by adding a `yerna.json` file:
+
+```json
+{
+  "packages": [
+    "packages/*",
+    "elsewhere/*"
+  ]
+}
+```
+
+This works in the same way as Lerna. The configuration file does not support any other properties.
 
 ### Caveats
 

--- a/bin/yerna
+++ b/bin/yerna
@@ -29,7 +29,7 @@ const gitRoot = child_process.execSync('git rev-parse --show-toplevel', {
 const config = readConfig(gitRoot);
 
 const PACKAGES = getPackages(gitRoot, config);
-if (PACKAGES.length === 0) {
+if (_.size(PACKAGES) === 0) {
   logger.error(chalk.red(`could not find any packages under ${config.packages}`));
   process.exitCode = 1;
 }

--- a/bin/yerna
+++ b/bin/yerna
@@ -13,21 +13,26 @@ const child_process = require('child_process');
 const fs = require('fs');
 const Promise = require('bluebird');
 
-const { getPackagesPath, getPackages } = require('../lib/packages');
+const { readConfig } = require('../lib/config');
+const { getPackages } = require('../lib/packages');
 const { linkPackages, WithLinking } = require('../lib/linking');
 const { runYarnWithPackageJsonMangling } = require('../lib/yarn-with-package-json-mangling');
 const { logger, deleteLogFile } = require('../lib/logger');
 const { filterPackages, logFlagFeedback } = require('../lib/filtering');
 const { createTaskRunner, runPackagesToposorted, abort, WithAbort } = require('../lib/taskrunning');
 
-const PACKAGES_PATH = getPackagesPath();
+const gitRoot = child_process.execSync('git rev-parse --show-toplevel', {
+  timeout: 5000,
+  stdio: 'pipe'
+}).toString().trim();
 
-if (!fs.existsSync(PACKAGES_PATH)) {
-  logger.error(chalk.red(`path ${PACKAGES_PATH} does not exist`));
+const config = readConfig(gitRoot);
+
+const PACKAGES = getPackages(gitRoot, config);
+if (PACKAGES.length === 0) {
+  logger.error(chalk.red(`could not find any packages under ${config.packages}`));
   process.exitCode = 1;
 }
-
-const PACKAGES = getPackages(PACKAGES_PATH);
 
 let didInit = false;
 function WithInit(fn) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,24 @@
+// Copyright 2017 Palantir Technologies Inc.
+
+const fs = require('fs');
+const path = require('path');
+
+const defaultConfig = {
+  packages: ['packages/*']
+};
+
+function readConfig(gitRoot) {
+  try {
+    const config = JSON.parse(fs.readFileSync(path.join(gitRoot, 'yerna.json')));
+    return Object.assign({}, defaultConfig, config);
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+    return defaultConfig;
+  }
+}
+
+module.exports = {
+  readConfig
+};

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -10,22 +10,10 @@ function trimTrailingNewline(s) {
   return s[s.length - 1] === '\n' ? s.slice(0, s.length - 1) : s;
 }
 
-function getPackagesPath() {
-  let gitRoot;
-  try {
-    gitRoot = trimTrailingNewline(child_process.execSync('git rev-parse --show-toplevel', {
-      timeout: 5000,
-      stdio: 'pipe'
-    }).toString());
-  } catch (e) {
-    throw new Error('cannot get path to root of git repo: ' + trimTrailingNewline(e.stderr.toString()));
-  }
-
-  return path.join(gitRoot, 'packages');
-}
-
-function getPackages(directory) {
-  const packagesByName = _.chain(glob.sync(path.join(directory, '*', 'package.json')))
+function getPackages(root, config) {
+  const packagesByName = _.chain(config.packages)
+    .map(packageGlob => path.join(root, packageGlob, 'package.json'))
+    .flatMap(packageJsonGlob => glob.sync(packageJsonGlob))
     .map(filename => {
       const packageJson = JSON.parse(fs.readFileSync(filename));
       return {
@@ -66,6 +54,5 @@ function getPackages(directory) {
 }
 
 module.exports = {
-  getPackages,
-  getPackagesPath
+  getPackages
 };


### PR DESCRIPTION
This works pretty much the same way as Lerna.

*Upside:* Makes it easier to manage a big monorepo, where you might not
want to put all the packages in one place.

*Downside:* Now there's a configuration file. I didn't want to read
`lerna.json` because I have no intention of supporting all the features,
and I got the feeling you don't either.

We find it useful, and hopefully others will too. 😄